### PR TITLE
Fix error in executeOnWindows() method

### DIFF
--- a/src/Snappdf.php
+++ b/src/Snappdf.php
@@ -293,6 +293,6 @@ class Snappdf
 
         $this->cleanup($pdf, $content);
 
-        return file_get_contents($pdfContent);
+        return $pdfContent;
     }
 }


### PR DESCRIPTION
This fixes https://github.com/beganovich/snappdf/issues/31

The `executeOnWindows()` method accidentally runs `file_get_contents()` twice:

```PHP
$pdfContent = file_get_contents($pdf);

$this->cleanup($pdf, $content);

return file_get_contents($pdfContent);
```

This causes snappdf to fail on Windows. Compare to the non-Windows code from the `generate()` method :

```PHP
$pdfContent = file_get_contents($pdf);

$this->cleanup($pdf, $content);

return $pdfContent;
```

This pull request simply removes the extra call to `file_get_contents()`, making the last three lines of `executeOnWindows()` the same as `generate()`.