### PR TITLE
Additional args for chromium

### DIFF
--- a/src/Snappdf.php
+++ b/src/Snappdf.php
@@ -40,7 +40,7 @@ class Snappdf
             '--no-first-run',
             '--no-margins',
             '--no-sandbox',
-            '--print-to-pdf-no-header',
+            '--no-pdf-header-footer',
             '--hide-scrollbars',
             '--ignore-certificate-errors',
         ];

--- a/src/Snappdf.php
+++ b/src/Snappdf.php
@@ -40,6 +40,7 @@ class Snappdf
             '--no-first-run',
             '--no-margins',
             '--no-sandbox',
+            '--print-to-pdf-no-header',
             '--no-pdf-header-footer',
             '--hide-scrollbars',
             '--ignore-certificate-errors',


### PR DESCRIPTION
This adds a CLI option 

I believe the change came about due to changes in switches

```
--headless=new and --headless=old 
=new --no-pdf-header-footer 
=old --print-to-pdf-no-header
```

Adding this flag is backward compatible from tests.