### PR TITLE
Bump Symfony dependencies to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "require": {
         "php": "^8.1|^8.2",
         "ext-zip": "*",
-        "symfony/process": "^6.2",
-        "symfony/console": "^6.2",
-        "symfony/filesystem": "^6.2"
+        "symfony/process": "^6.2|^7.0",
+        "symfony/console": "^6.2|^7.0",
+        "symfony/filesystem": "^6.2|^7.0"
     },
     "require-dev": {
         "ext-fileinfo": "*",


### PR DESCRIPTION
Laravel has upgraded to Symfony 7.0, would be great if we could upgrade and use this amazing package in Laravel 11.

Thanks.