### PR TITLE
Fix command injection on Windows (unescaped argv passed to exec)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,6 +10,7 @@ jobs:
   run:
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: ["ubuntu-latest", "windows-latest", "macos-latest"]
         php-versions: ["8.2", "8.3", "8.4", "8.5"]
@@ -21,6 +22,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
+          coverage: none
+          extensions: zip, fileinfo
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
@@ -36,9 +39,14 @@ jobs:
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
-      
-      - name: Download local revision of Chromium
+
+      - name: Download Chromium
         run: php snappdf download
+
+      - name: Use pre-installed Chrome on macOS
+        if: runner.os == 'macOS'
+        run: |
+          echo "SNAPPDF_EXECUTABLE_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" >> $GITHUB_ENV
 
       - name: PHPUnit tests
         run: php vendor/bin/phpunit --testdox

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: ["ubuntu-22.04"]
+        operating-system: ["ubuntu-latest", "windows-latest", "macos-latest"]
         php-versions: ["8.2", "8.3", "8.4", "8.5"]
 
     steps:

--- a/src/Snappdf.php
+++ b/src/Snappdf.php
@@ -247,12 +247,10 @@ class Snappdf
             $content['content'],
         );
 
-        $platform = (new DownloadChromiumCommand())->generatePlatformCode();
-
-        if ($platform == 'Win' || $platform == 'Win_x64') {
-            return $this->executeOnWindows($commandInput, $pdf, $content);
-        }
-
+        // Run the browser via an argv array on every platform. Symfony Process escapes
+        // arguments correctly on Windows too, so there is no need for a shell string (the
+        // previous executeOnWindows() built one with `exec(implode(' ', $commands))`, which
+        // let a tainted argument such as setUrl($url) inject shell commands on Windows).
         $process = new Process($commandInput);
 
         $process->run();
@@ -277,23 +275,4 @@ class Snappdf
         $filesystem->appendToFile($path, $pdf);
     }
 
-    private function executeOnWindows(array $commands, $pdf, array $content): ?string
-    {
-        $command = implode(' ', $commands) . ' 2>&1'; // must add 2>&1 to redirect stderr to stdout // see https://stackoverflow.com/a/16665146/7511165
-
-        exec($command, $output, $statusCode);
-
-        if ($statusCode && !empty($output)) {
-            // $output is an array of lines of the command output
-            $message = implode("\n", $output);
-            // ProcessFailedException accepts only a string as $message
-            throw new \Beganovich\Snappdf\Exception\ProcessFailedException($message);
-        }
-
-        $pdfContent = file_get_contents($pdf);
-
-        $this->cleanup($pdf, $content);
-
-        return $pdfContent;
-    }
 }


### PR DESCRIPTION
### Summary

On Windows, `generate()` routes execution through `executeOnWindows()`, which builds a single shell string and runs it through the shell:

```php
$command = implode(' ', $commands) . ' 2>&1';
exec($command, $output, $statusCode);
```

`$commands` is the argv array assembled in `generate()`, and it includes consumer-supplied values — notably `$content['content']`, which is the URL passed to `setUrl()`. Because nothing is escaped, a value containing shell metacharacters injects arbitrary commands. For example, an app that renders a user-influenced URL:

```php
$snappdf->setUrl($userUrl)->save($path);
// $userUrl = 'http://example ; calc.exe ;'  ->  exec('chromium ... http://example ; calc.exe ; 2>&1')
```

results in command execution on Windows. Linux/macOS are unaffected — they already run the browser via `new Process($commandInput)` (an argv array, no shell).

### Fix

`symfony/process` (`^7.4`, already required) escapes arguments correctly on Windows as well, so the shell string is unnecessary. This PR drops the Windows special-case and runs every platform through `new Process($commandInput)`. The previously-tainted argument is then a single literal argv element and cannot break out of the command.

I verified both directions locally: the old `exec(implode(...))` path executes an injected command, while the `Process($commandInput)` argv path does not (the URL is passed as one argument). The standard `Process` path already handles stderr via `getErrorOutput()` / `ProcessFailedException`, so the old `2>&1` merge isn't needed.

No API changes; behavior is identical for legitimate inputs.